### PR TITLE
commented clearInputs() method on PaymentFromFragment onResume() method

### DIFF
--- a/ioka/src/main/java/kz/ioka/android/ioka/presentation/flows/payment/PaymentFormFragment.kt
+++ b/ioka/src/main/java/kz/ioka/android/ioka/presentation/flows/payment/PaymentFormFragment.kt
@@ -104,7 +104,8 @@ internal class PaymentFormFragment : BaseFragment(R.layout.ioka_fragment_payment
         super.onResume()
 
         enableInputs()
-        clearInputs()
+//        Commented this line because clients copied card data from another app, so it should not be deleted on app switch
+//        clearInputs()
     }
 
     private fun bindViews(view: View) {


### PR DESCRIPTION
Airba fresh clients wanted to copy card data from another app, but our SDK cleared input any time application goes to a background mode. Fixed